### PR TITLE
Feat: usuario administrador

### DIFF
--- a/api/src/main/java/br/com/calculadorahoras/api/config/SecurityConfig.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                     .requestMatchers(HttpMethod.POST, "/auth/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "alarms/all").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.GET, "users/all").hasRole("ADMIN")
                     .anyRequest().authenticated()
                 )
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)

--- a/api/src/main/java/br/com/calculadorahoras/api/config/SecurityConfig.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                     .requestMatchers(HttpMethod.POST, "/auth/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "alarms/all").hasRole("ADMIN")
                     .anyRequest().authenticated()
                 )
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)

--- a/api/src/main/java/br/com/calculadorahoras/api/controller/AlarmsController.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/controller/AlarmsController.java
@@ -34,9 +34,6 @@ public class AlarmsController {
     @Autowired
     private TokenService tokenService;
 
-    @Autowired
-    private UserRepo userRepo;
-
     @GetMapping("alarms/all")
     public ResponseEntity<?> selectAllAlarmConfigs(@RequestHeader("Authorization") String authorizationHeader) {
         try {

--- a/api/src/main/java/br/com/calculadorahoras/api/controller/AlarmsController.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/controller/AlarmsController.java
@@ -39,7 +39,8 @@ public class AlarmsController {
         try {
             Iterable<AlertConfig> response = alertRepo.findAll();
             if (!response.iterator().hasNext()) {
-                return new ResponseEntity<>(new ErrorResponse(), HttpStatus.NOT_FOUND);
+                return new ResponseEntity<>(new ErrorResponse("Erro. Não foi encontrado nenhum alarme cadastrado. Tente mais tarde"),
+                                                                 HttpStatus.NOT_FOUND);
             } else {
                 return ResponseEntity.ok(response);
             }

--- a/api/src/main/java/br/com/calculadorahoras/api/controller/AlarmsController.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/controller/AlarmsController.java
@@ -37,17 +37,25 @@ public class AlarmsController {
     @Autowired
     private UserRepo userRepo;
 
-    // Habilitar o endpoint caso exista uma funcionalidade onde o Administrador possa editar essas configuracoes
-    // @GetMapping
-    // public ResponseEntity<?> selectAllAlarmConfigs() {
-    //     Iterable<AlertConfig> response = alertRepo.findAll();
-    //     if (!response.iterator().hasNext()) {
-    //         // retorna status 500 se a colecao de elementos estiver vazia
-    //         return new ResponseEntity<>(new ErrorResponse(), HttpStatus.INTERNAL_SERVER_ERROR);
-    //     } else {
-    //         return ResponseEntity.ok(response);
-    //     }
-    // }
+    @GetMapping("alarms/all")
+    public ResponseEntity<?> selectAllAlarmConfigs(@RequestHeader("Authorization") String authorizationHeader) {
+        String token = authorizationHeader.replace("Bearer ", "");
+        
+        try {
+            Iterable<AlertConfig> response = alertRepo.findAll();
+            if (!response.iterator().hasNext()) {
+                // retorna status 500 se a colecao de elementos estiver vazia
+                return new ResponseEntity<>(new ErrorResponse(), HttpStatus.NOT_FOUND);
+            } else {
+                return ResponseEntity.ok(response);
+            }
+        } catch (Exception e) {
+            return new ResponseEntity<>(
+                new ErrorResponse("Erro no processamento: " + e), 
+                HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        
+    }
 
 
     //Deprecated endpoint

--- a/api/src/main/java/br/com/calculadorahoras/api/controller/AlarmsController.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/controller/AlarmsController.java
@@ -39,12 +39,9 @@ public class AlarmsController {
 
     @GetMapping("alarms/all")
     public ResponseEntity<?> selectAllAlarmConfigs(@RequestHeader("Authorization") String authorizationHeader) {
-        String token = authorizationHeader.replace("Bearer ", "");
-        
         try {
             Iterable<AlertConfig> response = alertRepo.findAll();
             if (!response.iterator().hasNext()) {
-                // retorna status 500 se a colecao de elementos estiver vazia
                 return new ResponseEntity<>(new ErrorResponse(), HttpStatus.NOT_FOUND);
             } else {
                 return ResponseEntity.ok(response);

--- a/api/src/main/java/br/com/calculadorahoras/api/controller/AuthenticationController.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/controller/AuthenticationController.java
@@ -126,10 +126,10 @@ public class AuthenticationController {
     @PutMapping("users/update")
     public ResponseEntity<?> updateUser(@RequestBody UserDTO uDto, @RequestHeader("Authorization") String authorizationHeader){
         String token = authorizationHeader.replace("Bearer ", "");
-        
         try {
             UserTokenSubjectBody verified = UserTokenSubjectBody.convertStringToJson(tokenService.validateToken(token));
-            if(verified.getUserId() == uDto.id()){
+            String role = tokenService.getClaim(token, "papel");
+            if(verified.getUserId() == uDto.id() || role.equals("ADMINISTRADOR")){
                 Users originalData = userRepo.findById(uDto.id()).orElseThrow();
             
                 originalData.setWorkPlace(uDto.workplace());

--- a/api/src/main/java/br/com/calculadorahoras/api/controller/AuthenticationController.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/controller/AuthenticationController.java
@@ -1,6 +1,8 @@
 package br.com.calculadorahoras.api.controller;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
+import br.com.calculadorahoras.api.dtos.UserDTO;
 import br.com.calculadorahoras.api.model.Roles;
 import br.com.calculadorahoras.api.model.Users;
 import br.com.calculadorahoras.api.repo.RoleRepo;
@@ -96,7 +99,21 @@ public class AuthenticationController {
             if (!response.iterator().hasNext()) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse("Nenhum usuario encontrado"));
             } else {
-                return ResponseEntity.ok(response);
+                List<UserDTO>userDTOList = new ArrayList<>();
+                
+                response.forEach(user -> {
+                    UserDTO userDTO = new UserDTO(
+                        user.getId(),
+                        user.getUsername(), 
+                        user.getName(), 
+                        user.getSureName(), 
+                        user.getWorkPlace(),
+                        user.getRole());
+                    
+                    userDTOList.add(userDTO);
+                });
+
+                return ResponseEntity.ok(userDTOList);
             }
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(new ErrorResponse("Erro no processamento: " + e));

--- a/api/src/main/java/br/com/calculadorahoras/api/controller/AuthenticationController.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/controller/AuthenticationController.java
@@ -14,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
+import br.com.calculadorahoras.api.dtos.LoginDTO;
 import br.com.calculadorahoras.api.dtos.UserDTO;
 import br.com.calculadorahoras.api.model.AlertConfig;
 import br.com.calculadorahoras.api.model.Roles;
@@ -75,9 +76,9 @@ public class AuthenticationController {
     }
 
     @PostMapping("/auth/login")
-    public ResponseEntity<?> login(@RequestBody Users user) {
+    public ResponseEntity<?> login(@RequestBody LoginDTO loginDTO) {
         try {
-            var userPassword = new UsernamePasswordAuthenticationToken(user.getUsername(), user.getPassword());
+            var userPassword = new UsernamePasswordAuthenticationToken(loginDTO.username(), loginDTO.password());
             var auth = this.authenticationManager.authenticate(userPassword);
             if(auth.isAuthenticated()){
                 var token = tokenService.generateToken((Users) auth.getPrincipal());

--- a/api/src/main/java/br/com/calculadorahoras/api/controller/AuthenticationController.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/controller/AuthenticationController.java
@@ -21,6 +21,10 @@ import br.com.calculadorahoras.utils.ErrorResponse;
 
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
 
 
 
@@ -84,5 +88,20 @@ public class AuthenticationController {
         
         
     }
+
+    @GetMapping("users/all")
+    public ResponseEntity<?> listAllUsers(@RequestHeader("Authorization") String authorizationHeader) {
+        try {
+            Iterable<Users> response = userRepo.findAll();
+            if (!response.iterator().hasNext()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse("Nenhum usuario encontrado"));
+            } else {
+                return ResponseEntity.ok(response);
+            }
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body(new ErrorResponse("Erro no processamento: " + e));
+        }
+    }
+    
 
 }

--- a/api/src/main/java/br/com/calculadorahoras/api/dtos/LoginDTO.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/dtos/LoginDTO.java
@@ -1,0 +1,8 @@
+package br.com.calculadorahoras.api.dtos;
+
+public record LoginDTO(
+    String username,
+    String password
+) {
+
+}

--- a/api/src/main/java/br/com/calculadorahoras/api/dtos/UserDTO.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/dtos/UserDTO.java
@@ -1,0 +1,15 @@
+package br.com.calculadorahoras.api.dtos;
+
+import br.com.calculadorahoras.api.model.Roles;
+
+public record UserDTO(
+    int id,
+    String eMail,
+    String name,
+    String surename,
+    String workplace,
+    Roles role
+
+) {    
+
+}

--- a/api/src/main/java/br/com/calculadorahoras/api/services/TokenService.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/services/TokenService.java
@@ -23,9 +23,9 @@ public class TokenService {
     private String secret;
 
     public String generateToken(Users user) {
-        UserTokenSubjectBody utsb = new UserTokenSubjectBody(user.getUsername(), user.getId());
-
+        
         try {
+            UserTokenSubjectBody utsb = new UserTokenSubjectBody(user.getUsername(), user.getId());
             Algorithm algorithm = Algorithm.HMAC256(secret);
             ObjectMapper objectMapper = new ObjectMapper();
             String subject = objectMapper.writeValueAsString(utsb);

--- a/api/src/main/java/br/com/calculadorahoras/api/services/TokenService.java
+++ b/api/src/main/java/br/com/calculadorahoras/api/services/TokenService.java
@@ -33,6 +33,7 @@ public class TokenService {
             String token = JWT.create()
                     .withIssuer("auth-api")
                     .withSubject(subject)
+                    .withClaim("papel", user.getRole().getRoleName())
                     .withExpiresAt(genExpirationDate())
                     .sign(algorithm);
 
@@ -53,6 +54,22 @@ public class TokenService {
                     .getSubject();
         } catch (JWTVerificationException exception) {
             return "erro na validacao";
+        }
+    }
+
+    public String getClaim(String token, String claim){
+        try {
+            Algorithm algorithm = Algorithm.HMAC256(secret);
+
+            return JWT.require(algorithm)
+                    .withIssuer("auth-api")
+                    .build()
+                    .verify(token)
+                    .getClaim(claim)
+                    .asString();
+            
+        } catch (JWTVerificationException exception) {
+            throw new RuntimeException("Erro ao verificar o token", exception);
         }
     }
 

--- a/api/src/test/java/br/com/calculadorahoras/api/ApiAuthenticationTest.java
+++ b/api/src/test/java/br/com/calculadorahoras/api/ApiAuthenticationTest.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.Optional;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -25,14 +27,19 @@ import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import br.com.calculadorahoras.api.dtos.UserDTO;
 import br.com.calculadorahoras.api.model.Roles;
 import br.com.calculadorahoras.api.model.Users;
 import br.com.calculadorahoras.api.repo.RoleRepo;
 import br.com.calculadorahoras.api.repo.UserRepo;
 import br.com.calculadorahoras.api.services.TokenService;
+import br.com.calculadorahoras.utils.UserTokenSubjectBody;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -170,5 +177,72 @@ public class ApiAuthenticationTest {
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().json("{\"errorMessage\":\"Erro no processamento: java.lang.RuntimeException\"}"));
     }
+
+    @Test
+    @WithMockUser(username = "Picapau", roles = { "ADMIN" })
+    public void shouldListAllUsers() throws Exception{
+        UserDTO userDTO = new UserDTO(
+                        user.getId(),
+                        user.getUsername(), 
+                        user.getName(), 
+                        user.getSureName(), 
+                        user.getWorkPlace(),
+                        user.getRole());
+                    
+        ObjectMapper objectUserMapper = new ObjectMapper();
+        String dtoJson = objectUserMapper.writeValueAsString(userDTO);
+        
+        UserTokenSubjectBody validToken = new UserTokenSubjectBody("Picapau", 1);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String validJsonToken = objectMapper.writeValueAsString(validToken);
+
+        when(tokenService.validateToken("valid_token")).thenReturn(validJsonToken);
+        when(userRepo.findAll()).thenReturn(Arrays.asList(user));
+
+        mockMvc.perform(get("/users/all")
+                .header("Authorization", "Bearer valid_token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(dtoJson))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "Picapau", roles = { "ADMIN" })
+    public void shouldNotListAllUsers() throws Exception{
+                    
+        UserTokenSubjectBody validToken = new UserTokenSubjectBody("Picapau", 1);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String validJsonToken = objectMapper.writeValueAsString(validToken);
+
+        when(tokenService.validateToken("valid_token")).thenReturn(validJsonToken);
+        when(userRepo.findAll()).thenReturn(new ArrayList<Users>());
+
+        mockMvc.perform(get("/users/all")
+                .header("Authorization", "Bearer valid_token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"errorMessage\":\"Nenhum usuario encontrado\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "Picapau", roles = { "ADMIN" })
+    public void shouldThrowExceptionWhenListAllUsers() throws Exception{
+                    
+        UserTokenSubjectBody validToken = new UserTokenSubjectBody("Picapau", 1);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String validJsonToken = objectMapper.writeValueAsString(validToken);
+
+        when(tokenService.validateToken("valid_token")).thenReturn(validJsonToken);
+        when(userRepo.findAll()).thenThrow(new RuntimeException());
+
+        mockMvc.perform(get("/users/all")
+                .header("Authorization", "Bearer valid_token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"errorMessage\":\"Erro interno\"}"))
+                .andExpect(status().isInternalServerError());
+    }
+
+
+
 
 }

--- a/api/src/test/java/br/com/calculadorahoras/api/ApiAuthenticationTest.java
+++ b/api/src/test/java/br/com/calculadorahoras/api/ApiAuthenticationTest.java
@@ -242,6 +242,95 @@ public class ApiAuthenticationTest {
                 .andExpect(status().isInternalServerError());
     }
 
+    @Test 
+    @WithMockUser(username = "Picapau", roles = { "ADMIN" })
+    public void shouldUpdateUser() throws Exception{
+
+        UserDTO userDTO = new UserDTO(
+            1,
+            "testUser@mail.com", 
+            "name", 
+            "surename", 
+            "updatedWorkplace",
+            role);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String dtoJson = objectMapper.writeValueAsString(userDTO);
+
+        UserTokenSubjectBody validToken = new UserTokenSubjectBody("Picapau", 5);
+        ObjectMapper objectMapper2 = new ObjectMapper();
+        String validJsonToken = objectMapper2.writeValueAsString(validToken);
+
+        when(tokenService.validateToken("valid_token")).thenReturn(validJsonToken);
+        when(userRepo.findById(1)).thenReturn(Optional.of(user));
+        when(tokenService.getClaim(anyString(), anyString())).thenReturn("ADMINISTRADOR");
+
+        mockMvc.perform(put("/users/update")
+                .header("Authorization", "Bearer valid_token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(dtoJson))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{\"sucesso\":\"usuario atualizado sem erros!\"}"));
+
+    }
+
+    @Test 
+    @WithMockUser(username = "Picapau", roles = { "USER" })
+    public void shouldNotHavePermissionToUpdateUser() throws Exception{
+
+        UserDTO userDTO = new UserDTO(
+            1,
+            "testUser@mail.com", 
+            "name", 
+            "surename", 
+            "updatedWorkplace",
+            role);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String dtoJson = objectMapper.writeValueAsString(userDTO);
+
+        UserTokenSubjectBody validToken = new UserTokenSubjectBody("Picapau", 5);
+        ObjectMapper objectMapper2 = new ObjectMapper();
+        String validJsonToken = objectMapper2.writeValueAsString(validToken);
+
+        when(tokenService.validateToken("valid_token")).thenReturn(validJsonToken);
+        when(userRepo.findById(1)).thenReturn(Optional.of(user));
+        when(tokenService.getClaim(anyString(), anyString())).thenReturn("USUARIO");
+
+        mockMvc.perform(put("/users/update")
+                .header("Authorization", "Bearer valid_token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(dtoJson))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().json("{\"errorMessage\":\"Este usuario nao possui permissao para realizar essa operação\"}"));
+
+    }
+
+    @Test 
+    @WithMockUser(username = "Picapau", roles = { "ADMINISTRADOR" })
+    public void shouldThrowUpdateUserException() throws Exception{
+
+        UserTokenSubjectBody validToken = new UserTokenSubjectBody("Picapau", 5);
+        ObjectMapper objectMapper2 = new ObjectMapper();
+        String validJsonToken = objectMapper2.writeValueAsString(validToken);
+
+        when(tokenService.validateToken("valid_token")).thenReturn(validJsonToken);
+        when(userRepo.findById(1)).thenReturn(Optional.of(user));
+        when(tokenService.getClaim(anyString(), anyString())).thenReturn("ADMINISTRADOR");
+
+        mockMvc.perform(put("/users/update")
+                .header("Authorization", "Bearer valid_token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+                .andExpect(status().isInternalServerError());
+
+    }
+
+    
+
+    
+
+
 
 
 

--- a/api/src/test/java/br/com/calculadorahoras/api/ApiTokenizationTest.java
+++ b/api/src/test/java/br/com/calculadorahoras/api/ApiTokenizationTest.java
@@ -3,27 +3,40 @@ package br.com.calculadorahoras.api;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.util.Assert;
 
+import br.com.calculadorahoras.api.model.Roles;
 import br.com.calculadorahoras.api.model.Users;
 import br.com.calculadorahoras.api.services.TokenService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 public class ApiTokenizationTest {
-    
+    private Roles roles;
+
     @Autowired
     private TokenService tokenService;
 
+    @BeforeEach
+    public void setup(){
+        roles = new Roles();
+        roles.setId(1);
+        roles.setRoleName("USUARIO");
+        roles.setDetails("Teste de token");
+    }
 
     @Test
     public void shouldGenerateToken(){
+        
         Users user = new Users();
         user.setUsername("justAnUser");
+        user.setRole(roles);
 
         String token = tokenService.generateToken(user);
         Assert.notNull(token, "failed");
@@ -34,6 +47,7 @@ public class ApiTokenizationTest {
         Users user = new Users();
         user.setUsername("justAnUser");
         user.setId(7);
+        user.setRole(roles);
 
         String token = tokenService.generateToken(user);
 

--- a/api/src/test/java/br/com/calculadorahoras/api/ApiTokenizationTest.java
+++ b/api/src/test/java/br/com/calculadorahoras/api/ApiTokenizationTest.java
@@ -2,6 +2,7 @@ package br.com.calculadorahoras.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +44,14 @@ public class ApiTokenizationTest {
     }
 
     @Test
+    public void shouldThrowGenerateTokenException(){
+
+        assertThrows(RuntimeException.class, () -> {
+            tokenService.generateToken(null);
+        });
+    }
+
+    @Test
     public void shouldValidateToken(){
         Users user = new Users();
         user.setUsername("justAnUser");
@@ -61,6 +70,30 @@ public class ApiTokenizationTest {
         String validation = tokenService.validateToken("invalidToken");
 
         assertEquals("erro na validacao", validation);
+    }
+
+    @Test
+    public void shouldGetClaim(){
+        Users user = new Users();
+        user.setUsername("TestUser@mail.com");
+        user.setPassword("badpassword");
+        user.setRole(roles);
+
+        String token = tokenService.generateToken(user);
+        String claim = tokenService.getClaim(token, "papel");
+
+        assertEquals("USUARIO", claim);
+    }
+
+    @Test
+    public void shouldThrowClaimException(){
+
+        String invalidToken = "tokenInvalido";
+        String claimName = "randomClaim";
+
+        assertThrows(RuntimeException.class, () -> {
+            tokenService.getClaim(invalidToken, claimName);
+        });
     }
 
 }


### PR DESCRIPTION
# Objetivo:
 Permitir que diferentes usuários tenham diferentes papeis de acesso.

## Tarefas

1. Administrador pode listar todos os usuários.
2. Administrador pode alterar endereço e setor de trabalho.
3. Retornar no token o papel para alterar os acessos no front.

## Critério de aceitação:
- [ ] Implementação com testes unitários com 80% de cobertura mínima
- [ ]  Testes de usabilidade, executados juntamente com um responsável 
- [ ] PR aceito.

## Cobertura de testes:
![image](https://github.com/user-attachments/assets/15eeb907-8a43-45ac-b800-7fa01617bb5d)
